### PR TITLE
Fixes running cram with a supplied config file

### DIFF
--- a/lib/config/merge.js
+++ b/lib/config/merge.js
@@ -6,11 +6,13 @@ define(function (require) {
 	function mergeConfigs (baseCfg, configFiles) {
 		var base, i, len, cfg;
 		base = baseCfg || {};
-		for (i = 0, len = configFiles.length; i < len; i++) {
-			cfg = configFiles[i];
-			base = mergeObjects(base, cfg);
-		}
-		return base;
+    return when(configFiles, function(files){
+      for (i = 0, len = files.length; i < len; i++) {
+        cfg = files[i];
+        base = mergeObjects(base, cfg);
+      }
+      return base;
+    });
 	}
 
 	// export testable things

--- a/lib/config/merge.js
+++ b/lib/config/merge.js
@@ -40,10 +40,11 @@ define(function (require) {
 		var combined, prev;
 
 		if (!identity) identity = defaultIdentity;
+
 		combined = (base || []).concat(ext || []).sort(sort);
 
 		return combined.reduce(function (result, item) {
-			if (identity(item) != identity(prev)) result.push(item);
+			if (item != prev) result.push(item);
 			prev = item;
 			return result;
 		}, []);


### PR DESCRIPTION
1. Wrap configFiles in a when to actually read from them
2. Remove call to identity; when comparing two objects with a "name" attribute that have different "location" attributes (curl setup) it will always pick the one from the app, which is the opposite of what I want.
